### PR TITLE
fixes limit/offset syntax error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,7 +404,7 @@ pub mod query_builder {
             }
 
             if self.offset != 0 {
-                query += ", ";
+                query += " OFFSET ";
                 query += self.offset.to_string().as_str();
             }
 
@@ -580,7 +580,7 @@ mod tests {
             .limit(15)
             .offset(30)
             .build();
-        assert_eq!("SELECT id, name FROM users LIMIT 15, 30;", query);
+        assert_eq!("SELECT id, name FROM users LIMIT 15 OFFSET 30;", query);
     }
 
     #[test]


### PR DESCRIPTION
Hi @jacobbudin ! Thanks for this library, easy to use !

Just noticed that the `LIMIT`/`OFFSET` syntax was broken. `LIMIT x, y` in Mysql, does the same as `LIMIT y OFFSET x`. And also `LIMIT x, y` does not work with Sqlite or Postgres.

`LIMIT x OFFSET y` works in all 3 databases according to the docs. This is what this commit is about.